### PR TITLE
refactor Form component to function based with usecontext hook

### DIFF
--- a/src/Form.js
+++ b/src/Form.js
@@ -1,7 +1,6 @@
-import React, {Component} from 'react';
+import React, {useContext} from 'react';
 import Avatar from "@material-ui/core/Avatar";
 import Button from "@material-ui/core/Button";
-import CssBaseline from "@material-ui/core/CssBaseline";
 import FormControl from "@material-ui/core/FormControl";
 import FormControlLabel from "@material-ui/core/FormControlLabel";
 import Checkbox from "@material-ui/core/Checkbox";
@@ -37,50 +36,56 @@ const words = {
     }
 };
 
-class Form extends Component {
-    static contextType = LanguageContext;
-    render() {
-        const { language, changeLanguage } = this.context;
-        const { classes } = this.props;
-        const { signIn, email, password, remember } = words[language];
-        return (
-            <main className={classes.main}>
-                <Paper className={classes.paper}>
-                    <Avatar className="classes.avatar">
-                        <LockOutlinedIcon />
-                    </Avatar>
-                    <Typography variant="h5">{signIn}</Typography>
-                    <Select value={language} onChange={changeLanguage}>
-                        <MenuItem value="english">English</MenuItem>
-                        <MenuItem value="french">French</MenuItem>
-                        <MenuItem value="spanish">Spanish</MenuItem>
-                    </Select>
-                    <form className={classes.form}>
-                        <FormControl margin="normal" required fullWidth>
-                            <InputLabel htmlFor="email">{email}</InputLabel>
-                            <Input id="email" name="email" autoFocus />
-                        </FormControl>
-                        <FormControl margin="normal" required fullWidth>
-                            <InputLabel htmlFor="password">{password}</InputLabel>
-                            <Input id="password" name="password" autoFocus />
-                        </FormControl>
-                        <FormControlLabel 
-                            control={<Checkbox colors="primary" />}
-                            label={remember}
-                        />
-                        <Button
-                            variant="contained"
-                            type="submit"
-                            fullWidth
-                            color="primary"
-                            className={classes.submit}
-                        >{signIn}
-                        </Button>
-                    </form>
-                </Paper>
-            </main>
-        )
-    }
+function Form(props) {
+    const { language, changeLanguage } = useContext(LanguageContext);
+    const { classes } = props;
+    const { signIn, email, password, remember } = words[language];
+    return (
+        <main className={classes.main}>
+            <Paper className={classes.paper}>
+                <Avatar className="classes.avatar">
+                    <LockOutlinedIcon />
+                </Avatar>
+                <Typography variant="h5">{signIn}</Typography>
+                <Select value={language} onChange={changeLanguage}>
+                    <MenuItem value="english">English</MenuItem>
+                    <MenuItem value="french">French</MenuItem>
+                    <MenuItem value="spanish">Spanish</MenuItem>
+                </Select>
+                <form className={classes.form}>
+                    <FormControl margin="normal" required fullWidth>
+                        <InputLabel htmlFor="email">{email}</InputLabel>
+                        <Input id="email" name="email" autoFocus />
+                    </FormControl>
+                    <FormControl margin="normal" required fullWidth>
+                        <InputLabel htmlFor="password">{password}</InputLabel>
+                        <Input id="password" name="password" autoFocus />
+                    </FormControl>
+                    <FormControlLabel 
+                        control={<Checkbox colors="primary" />}
+                        label={remember}
+                    />
+                    <Button
+                        variant="contained"
+                        type="submit"
+                        fullWidth
+                        color="primary"
+                        className={classes.submit}
+                    >{signIn}
+                    </Button>
+                </form>
+            </Paper>
+        </main>
+    )
 }
+// class Form extends Component {
+//     static contextType = LanguageContext;
+//     render() {
+        
+//         return (
+            
+//         )
+//     }
+// }
 
 export default withStyles(styles)(Form);


### PR DESCRIPTION
This is refactoring the `Form` Component to be a functional-based component instead of class-based.  Also, this makes use of the `useContext` hook.

In the `Form.js` file, the Component is refactored to now use a function by using `function Form(props)`, where the `props` are being passed in.  This replaces the use of the `class Form extends Component` way of writing this.  All the markup inside the `return` is retained, but the `render` line is removed.  At the top of the code, `Component` is no longer imported since this isn't class-based.  At the same time, the hook `useContext` is imported.  While here, the importing of `CssBaseline` was removed up top, since this wasn't being used.

To use the `useContext` hook, the previous reference to the `LanguageContext` with the use of the `static contextType` is no longer valid.  The same variables are retained before the `return` as previously, but are rewritten some.  Instead, the line `useContext(LanguageContext)` is used, to retrieve the same values from the Language Component of `language` and `changeLanguage`.  The line of `const classes` is now just equal to `props`, instead of `this.props`.  The other variable to retrieve the words of `language` is left unchanged.