### PR TITLE
refactor Navbar component to function based with usecontext hook

### DIFF
--- a/src/Navbar.js
+++ b/src/Navbar.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { useContext } from 'react';
 import AppBar from "@material-ui/core/AppBar";
 import ToolBar from "@material-ui/core/ToolBar";
 import IconButton from "@material-ui/core/IconButton";
@@ -9,7 +9,7 @@ import Switch from "@material-ui/core/Switch";
 import { withStyles } from "@material-ui/core/styles";
 import styles from "./styles/NavBarStyles";
 import { ThemeContext } from "./contexts/ThemeContext";
-import { withLanguageContext } from "./contexts/LanguageContext";
+import { LanguageContext } from "./contexts/LanguageContext";
 
 const content = {
     english: {
@@ -27,42 +27,39 @@ const content = {
     }
 };
 
-class Navbar extends Component {
-    static contextType = ThemeContext;
-    render() {
-        const { isDarkMode, toggleTheme } = this.context;
-        const { classes } = this.props;
-        const { language } = this.props.languageContext;
-        const { search, flag } = content[language];
-        return (
-            <div className={classes.root}>
-                <AppBar position="static" color={ isDarkMode ? "default" : "primary" }>
-                    <ToolBar>
-                        <IconButton className={classes.menuButton} color="inherit">
-                            <span role="img" aria-label="flag" style= {{marginTop: "7px"}}>{flag}</span>
-                        </IconButton>
-                        <Typography className={classes.title} varient="h6" color="inherit">
-                            App Title
-                        </Typography>
-                        <Switch onChange={toggleTheme} />
-                        <div className={classes.grow} />
-                        <div className={classes.search}>
-                            <div className={classes.searchIcon}>
-                                <SearchIcon />
-                            </div>
-                            <InputBase 
-                                placeholder= {`${search}...`}
-                                classes={{
-                                    root: classes.inputRoot,
-                                    input: classes.inputInput 
-                                }}
-                            />
+function Navbar(props) {
+    const { isDarkMode, toggleTheme } = useContext(ThemeContext);
+    const { language } = useContext(LanguageContext);
+    const { classes } = props;
+    const { search, flag } = content[language];
+    return (
+        <div className={classes.root}>
+            <AppBar position="static" color={ isDarkMode ? "default" : "primary" }>
+                <ToolBar>
+                    <IconButton className={classes.menuButton} color="inherit">
+                        <span role="img" aria-label="flag" style= {{marginTop: "7px"}}>{flag}</span>
+                    </IconButton>
+                    <Typography className={classes.title} varient="h6" color="inherit">
+                        App Title
+                    </Typography>
+                    <Switch onChange={toggleTheme} />
+                    <div className={classes.grow} />
+                    <div className={classes.search}>
+                        <div className={classes.searchIcon}>
+                            <SearchIcon />
                         </div>
-                    </ToolBar>
-                </AppBar>
-            </div>
-        )
-    }
+                        <InputBase 
+                            placeholder= {`${search}...`}
+                            classes={{
+                                root: classes.inputRoot,
+                                input: classes.inputInput 
+                            }}
+                        />
+                    </div>
+                </ToolBar>
+            </AppBar>
+        </div>
+    )
 }
 
-export default withLanguageContext(withStyles(styles)(Navbar));
+export default withStyles(styles)(Navbar);

--- a/src/contexts/LanguageContext.js
+++ b/src/contexts/LanguageContext.js
@@ -21,10 +21,3 @@ export class LanguageProvider extends Component {
         )
     }
 }
-
-// Higher Order Component
-export const withLanguageContext = Component => props => (
-    <LanguageContext.Consumer>
-        {value => <Component languageContext={value} {...props} />}
-    </LanguageContext.Consumer>
-)


### PR DESCRIPTION
This is refactoring the `Navbar` Component to be a functional-based component instead of class-based. Also, this makes use of the `useContext` hook twice.

In the `Navbar.js` file, the Component is refactored to now use a function by using `function Navbar(props)`, where the props are being passed in. This replaces the use of the `class Form extends Component` way of writing this. All the markup inside the `return` is retained, but the `render` line is removed. At the top of the code, `Component` is no longer imported since this isn't class-based. At the same time, the hook `useContext` is imported. Also, instead of importing the `withLanguageContext` from the `LanguageContext` component (which had been accessing a higher order component), now it is set to just import `LanguageContext`.

The `export` at the bottom is updated to no longer be wrapped with the `withLanguageContext`, since the higher order component is no longer needed.  To use the `useContext` hook, the previous reference to the `ThemeContext` with the use of the `static contextType` is no longer valid. The same variables are retained before the return as previously, but are rewritten. Instead, the `useContext(ThemeContext)` is used, to retrieve the same values from the `ThemeContext` Component, which are `isDarkMode` and `ToggleTheme`.  A second `useContext`, the `useContext(LanguageContext)` is also used.  It retrieves the same value from the `LanguageContext` Component of `language`.  The line of `const classes` is now just equal to `props`, instead of `this.props`. The other variable to retrieve the `content` of language is left unchanged.

In the `LanguageContext.js` file, the higher order component is removed from the code.