### PR TITLE
refactor languageContext component to functional with useState hook

### DIFF
--- a/src/contexts/LanguageContext.js
+++ b/src/contexts/LanguageContext.js
@@ -1,23 +1,14 @@
-import React, {Component, createContext} from 'react';
+import React, { createContext, useState } from 'react';
 
 export const LanguageContext = createContext();
 
-export class LanguageProvider extends Component {
-    constructor(props) {
-        super(props);
-        this.state = {language: "english"};
-        this.changeLanguage = this.changeLanguage.bind(this);
-    }
+export function LanguageProvider(props) {
+    const [language, setLanguage] = useState("english");
+    const changeLanguage = e => setLanguage(e.target.value);
 
-    changeLanguage(e) {
-        this.setState({ language: e.target.value })
-    };
-
-    render() {
-        return (
-            <LanguageContext.Provider value={{ ...this.state, changeLanguage: this.changeLanguage }}>
-                {this.props.children}
-            </LanguageContext.Provider>
-        )
-    }
+    return (
+        <LanguageContext.Provider value={{ language, changeLanguage }}>
+            {props.children}
+        </LanguageContext.Provider>
+    )
 }


### PR DESCRIPTION
This refactors the `languageContext` component to be a functional-based component, and implements the `useState` hook.

In the `import` up top, the `Component` is no longer imported from React, and the `useState` hook is added.  The component is then rewritten to be a function instead of a class, and takes the argument of `props`.  The `constructor` is then replaced with the `useState` hook, that will be used to set the `language` and the `setLanguage`.   The state is then given an initial value of "english".  

Also, a `changeLanguage` function is created to update the state by using `setLanguage`, which will equal the `e.target.value` with the event `(e)` that is passed in.  The previous `changeLanguage` function is removed.  The `render()` is removed.  Now, the `return` is set where the `languageContext.Provider` is set to the `value` of `language` and `changeLanguage`, with the key/value pair equal to the same for each.  Also the keyword `this` is dropped off from the `props.children` that is being passed through.