### PR TITLE
refactor ThemeContext component to functional with custom useToggle hook

### DIFF
--- a/src/contexts/ThemeContext.js
+++ b/src/contexts/ThemeContext.js
@@ -1,22 +1,14 @@
-import React, {Component, createContext} from 'react';
+import React, { createContext } from 'react';
+import useToggle from '../hooks/useToggleState';
 
 export const ThemeContext = createContext();
 
-export class ThemeProvider extends Component {
-    constructor(props) {
-        super(props);
-        this.state = { isDarkMode: false };
-        this.toggleTheme = this.toggleTheme.bind(this);
-    }
+export function ThemeProvider(props) {
+    const [isDarkMode, toggleTheme] = useToggle(false);
 
-    toggleTheme() {
-        this.setState({ isDarkMode: !this.state.isDarkMode });
-    }
-    render() {
-        return (
-            <ThemeContext.Provider value={{ ...this.state, toggleTheme: this.toggleTheme }}>
-                {this.props.children}
-            </ThemeContext.Provider>
-        )
-    }    
+    return (
+        <ThemeContext.Provider value={{ isDarkMode, toggleTheme }}>
+            {props.children}
+        </ThemeContext.Provider>
+    ) 
 }

--- a/src/hooks/useToggleState.js
+++ b/src/hooks/useToggleState.js
@@ -1,0 +1,13 @@
+import { useState} from "react";
+
+function useToggle(initialVal=false) {
+    // call useState hook
+    const [state, setState] = useState(initialVal);
+    const toggle = () => {
+        setState(!state);
+    }
+    // return piece of state and a function to toggle it
+    return[state, toggle];
+}
+
+export default useToggle;


### PR DESCRIPTION
This is refactoring the `ThemeContext` component to be a function-based component that uses a custom re-useable hook named `useToggle`.

First, a custom hook is created that can handle a toggle.  This is done by making a new folder named `hooks` and inside there, making a file named `useToggleState.js`.  At the top, this imports `useState` from `react`.  Then a functional component is made named `useToggle`, with an initial value passed in of `false`.  This is set up to be re-useable.  The `useState` hook is set to reserve a piece of state.  Then a `toggle` function is created, that flips the state from false to true, and alternates.  The entire functional component is then set to `return` two things: the `state`, and the function `toggle` so the state can be flipped.  This functional component is then exported.

In `ThemeContext.js`, the `import` at the top is updated to no longer import `Component` from `react`. The `useToggle` component is imported from `useToggleState`.  The component is updated to be a functional component, instead of class-based.  Now the `useToggle` hook is used.  We give the `state` the name previously used of `isDarkMode`, and the toggle portion of the hook is given a name of `toggleTheme`.  An initial value of state is provided of `false`.  At the bottom of this function, the `render()` is also removed, as it's no longer needed.