### PR TITLE
refactor PageContent component to function based with usecontext hook

### DIFF
--- a/src/PageContent.js
+++ b/src/PageContent.js
@@ -1,18 +1,14 @@
-import React, {Component} from 'react';
+import React, { useContext } from 'react';
 import {ThemeContext} from './contexts/ThemeContext';
 
-export default class PageContent extends Component {
-    static contextType = ThemeContext;
-    render() {
-        const { isDarkMode } = this.context;
-        const styles = {
-            backgroundColor: isDarkMode ? "black" : "white",
-            height: "100vh",
-            width: "100vw"            
-        }
-
-        return (
-            <div style={styles}>{this.props.children}</div>
-        )
+export default function PageContent(props) {
+    const { isDarkMode } = useContext(ThemeContext);
+    const styles = {
+        backgroundColor: isDarkMode ? "black" : "white",
+        height: "100vh",
+        width: "100vw"            
     }
+    return (
+        <div style={styles}>{props.children}</div>
+    )    
 }

--- a/src/contexts/ThemeContext.js
+++ b/src/contexts/ThemeContext.js
@@ -1,10 +1,10 @@
 import React, { createContext } from 'react';
-import useToggle from '../hooks/useToggleState';
+import useToggleState from '../hooks/useToggleState';
 
 export const ThemeContext = createContext();
 
 export function ThemeProvider(props) {
-    const [isDarkMode, toggleTheme] = useToggle(false);
+    const [isDarkMode, toggleTheme] = useToggleState(false);
 
     return (
         <ThemeContext.Provider value={{ isDarkMode, toggleTheme }}>

--- a/src/hooks/useToggleState.js
+++ b/src/hooks/useToggleState.js
@@ -1,6 +1,6 @@
 import { useState} from "react";
 
-function useToggle(initialVal=false) {
+function useToggleState(initialVal=false) {
     // call useState hook
     const [state, setState] = useState(initialVal);
     const toggle = () => {
@@ -10,4 +10,4 @@ function useToggle(initialVal=false) {
     return[state, toggle];
 }
 
-export default useToggle;
+export default useToggleState;


### PR DESCRIPTION
This refactors the `PageContent` component to be functional based, and incorporates the `useContext` hook.

In the `PageContent.js` file, the `import` for `Component` is removed, and instead the `useContext` hook is now imported.  The component is updated from class-based to a functional component.  Then it is updated to access the context by using the `useContext` hook, and setting the context to `ThemeContext`.  The value of `isDarkMode` is used from the context.  Also in this component, since this is now a function, the `render` is removed.  In the `return`, `this` is removed from the `div`, to now just make it `props.children`.  Also, in the function, `props` is now passed in as an argument.

Also edited was the `hooks/useToggleState.js` file and the `contexts/ThemeContext.js` file.  Here, it was just renaming the component function to be `useToggleState`, its `export` name, and the various references to it.  This was to match the name of the file, instead of the previous `useToggle`.